### PR TITLE
Feat/http client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ AMK is a minimal, no-frills REST API server built with **Express.js**, **Knex.js
 │   └── seed_data.js        # Seed script for continents, countries, and persons
 ├── http/
 │   ├── api.http            # JetBrains HTTP Client requests for all API endpoints
-│   └── http-client.env.json# Environment configs (dev / docker) for the HTTP Client
+│   └── http-client.env.json # Environment configs (dev / docker) for the HTTP Client
 ├── knexfile.js             # Knex configuration (development + test environments)
 ├── package.json            # Dependencies and npm scripts
 ├── .c8rc                   # Coverage reporter configuration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,9 @@ AMK is a minimal, no-frills REST API server built with **Express.js**, **Knex.js
 │   └── *.js                # Knex migration files
 ├── seeds/
 │   └── seed_data.js        # Seed script for continents, countries, and persons
+├── http/
+│   ├── api.http            # JetBrains HTTP Client requests for all API endpoints
+│   └── http-client.env.json# Environment configs (dev / docker) for the HTTP Client
 ├── knexfile.js             # Knex configuration (development + test environments)
 ├── package.json            # Dependencies and npm scripts
 ├── .c8rc                   # Coverage reporter configuration

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ sample backend using express.js, knex.js, and amk plugins
 3. Run the app: `npm start`
 4. Call the API endpoint: `curl http://localhost:3000/persons`
 
+## Try the API with JetBrains HTTP Client
+The `http/` folder contains [JetBrains HTTP Client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) files:
+- `http/api.http` — ready-to-run requests for every endpoint (list, get, filter, sort, paginate, create)
+- `http/http-client.env.json` — environments for `dev` (`localhost:3000`) and `docker` (`localhost:4000`)
+
+Open `http/api.http` in any JetBrains IDE, pick the environment from the dropdown, and run individual requests from the gutter icons.
+
 ## Initialize DB and seed data
 1. Run migrations: `npm run migrate`
 2. Run seeds: `npm run seed`

--- a/http/api.http
+++ b/http/api.http
@@ -1,0 +1,131 @@
+# AMK API — JetBrains HTTP Client requests
+# Base URL is configured in http-client.env.json
+# Run individual requests by clicking the gutter icon in IntelliJ / WebStorm / Rider.
+
+### Variables (local scope)
+# These can be overridden per-request or in the environment file.
+
+# ------------------------------------------------------------------------------
+# Health / Root
+# ------------------------------------------------------------------------------
+
+### List all routes (implicit — hit base)
+GET {{host}}/persons
+
+# ------------------------------------------------------------------------------
+# Continents
+# ------------------------------------------------------------------------------
+
+### List all continents
+GET {{host}}/continents
+
+### Get a single continent — Asia
+GET {{host}}/continents/AS
+
+### Get a single continent — Europe
+GET {{host}}/continents/EU
+
+### Get a single continent — Not Found
+GET {{host}}/continents/XX
+
+# ------------------------------------------------------------------------------
+# Countries
+# ------------------------------------------------------------------------------
+
+### List all countries (paginated, default limit 10)
+GET {{host}}/countries
+
+### List countries — filter by continent (Europe)
+GET {{host}}/countries?continent_code=EU
+
+### List countries — filter by name substring ("land")
+GET {{host}}/countries?name=land
+
+### List countries — filter by exact currency
+GET {{host}}/countries?currency=EUR
+
+### List countries — sorted by name descending
+GET {{host}}/countries?sort=-name
+
+### List countries — sorted by name ascending
+GET {{host}}/countries?sort=+name
+
+### List countries — pagination (offset 5, limit 5)
+GET {{host}}/countries?offset=5&limit=5
+
+### List countries — combined filter + sort + pagination
+GET {{host}}/countries?continent_code=AS&sort=-name&limit=5&offset=0
+
+### Get a single country — United States
+GET {{host}}/countries/US
+
+### Get a single country — France
+GET {{host}}/countries/FR
+
+### Get a single country — Not Found
+GET {{host}}/countries/ZZ
+
+# ------------------------------------------------------------------------------
+# Persons
+# ------------------------------------------------------------------------------
+
+### List all persons (paginated, default limit 10)
+GET {{host}}/persons
+
+### List persons — filter by first name substring ("John")
+GET {{host}}/persons?first_name=John
+
+### List persons — filter by last name substring ("Doe")
+GET {{host}}/persons?last_name=Doe
+
+### List persons — filter by country code
+GET {{host}}/persons?country_code=US
+
+### List persons — sorted by first name descending
+GET {{host}}/persons?sort=-first_name
+
+### List persons — pagination (offset 2, limit 3)
+GET {{host}}/persons?offset=2&limit=3
+
+### List persons — combined filter + sort + pagination
+GET {{host}}/persons?country_code=US&sort=-last_name&limit=2&offset=0
+
+### Get a single person (ID must exist — seeded IDs start at 1)
+GET {{host}}/persons/1
+
+### Get a single person — Not Found
+GET {{host}}/persons/99999
+
+### Create a new person — valid payload
+POST {{host}}/persons
+Content-Type: application/json
+
+{
+  "first_name": "Alice",
+  "last_name": "Wonder",
+  "country_code": "US"
+}
+
+### Create a new person — minimal valid payload (only required fields)
+POST {{host}}/persons
+Content-Type: application/json
+
+{
+  "first_name": "Bob",
+  "country_code": "FR"
+}
+
+### Create a new person — invalid payload (missing required field)
+POST {{host}}/persons
+Content-Type: application/json
+
+{
+  "last_name": "MissingFirstName",
+  "country_code": "GB"
+}
+
+### Create a new person — invalid payload (empty body)
+POST {{host}}/persons
+Content-Type: application/json
+
+{}

--- a/http/api.http
+++ b/http/api.http
@@ -9,7 +9,7 @@
 # Health / Root
 # ------------------------------------------------------------------------------
 
-### List all routes (implicit — hit base)
+### List persons (quick start)
 GET {{host}}/persons
 
 # ------------------------------------------------------------------------------
@@ -48,7 +48,7 @@ GET {{host}}/countries?currency=EUR
 GET {{host}}/countries?sort=-name
 
 ### List countries — sorted by name ascending
-GET {{host}}/countries?sort=+name
+GET {{host}}/countries?sort=name
 
 ### List countries — pagination (offset 5, limit 5)
 GET {{host}}/countries?offset=5&limit=5

--- a/http/http-client.env.json
+++ b/http/http-client.env.json
@@ -1,0 +1,8 @@
+{
+  "dev": {
+    "host": "http://localhost:3000"
+  },
+  "docker": {
+    "host": "http://localhost:4000"
+  }
+}


### PR DESCRIPTION
This pull request adds support for using the JetBrains HTTP Client to easily test all API endpoints in the project. It introduces a new `http/` directory containing ready-to-run HTTP request files and environment configurations, and updates the documentation to guide users on how to use these tools.

**JetBrains HTTP Client integration:**

* Added the `http/` directory with two files:
  * `api.http` — contains example requests for all API endpoints, covering listing, filtering, sorting, pagination, and creation for `continents`, `countries`, and `persons`.
  * `http-client.env.json` — defines environments for development (`localhost:3000`) and Docker (`localhost:4000`).
* Updated `README.md` and `AGENTS.md` to document the new HTTP Client files and provide instructions for running and customizing requests in JetBrains IDEs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R14-R20) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R52-R54)